### PR TITLE
Disabling failing test associated with a dataset that contains and unnamed array

### DIFF
--- a/bes-testsuite/hdf4_handlerTest.with_hdfeos2.at
+++ b/bes-testsuite/hdf4_handlerTest.with_hdfeos2.at
@@ -274,7 +274,16 @@ AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_dim_mismatch.hdf.ddx.bescmd])
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.das.bescmd])
 AT_BESCMD_BINARYDATA_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.data.bescmd])
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.dds.bescmd])
-AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.ddx.bescmd])
+#
+#
+# This test fails because cahnges to libdap4 altered the contents
+# of the metada. The associated ticket is:
+# https://opendap.atlassian.net/browse/HYRAX-399
+# and this test should be enabled once the ticket is resolved.
+#
+# AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.ddx.bescmd])
+#
+#
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xyz.hdf.das.bescmd])
 AT_BESCMD_BINARYDATA_RESPONSE_TEST([swath_1_2d_xyz.hdf.data.bescmd])
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xyz.hdf.dds.bescmd])

--- a/bes-testsuite/hdf4_handlerTest.with_hdfeos2.at
+++ b/bes-testsuite/hdf4_handlerTest.with_hdfeos2.at
@@ -271,18 +271,16 @@ AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_dim_mismatch.hdf.das.bescmd])
 AT_BESCMD_BINARYDATA_RESPONSE_TEST([swath_1_2d_xy_dim_mismatch.hdf.data.bescmd])
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_dim_mismatch.hdf.dds.bescmd])
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_dim_mismatch.hdf.ddx.bescmd])
-AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.das.bescmd])
-AT_BESCMD_BINARYDATA_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.data.bescmd])
-AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.dds.bescmd])
 #
-#
-# This test fails because cahnges to libdap4 altered the contents
+# These tests fails because cahnges to libdap4 altered the contents
 # of the metada. The associated ticket is:
 # https://opendap.atlassian.net/browse/HYRAX-399
 # and this test should be enabled once the ticket is resolved.
 #
+# AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.das.bescmd])
+# AT_BESCMD_BINARYDATA_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.data.bescmd])
+# AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.dds.bescmd])
 # AT_BESCMD_RESPONSE_TEST([swath_1_2d_xy_no_dim.hdf.ddx.bescmd])
-#
 #
 AT_BESCMD_RESPONSE_TEST([swath_1_2d_xyz.hdf.das.bescmd])
 AT_BESCMD_BINARYDATA_RESPONSE_TEST([swath_1_2d_xyz.hdf.data.bescmd])


### PR DESCRIPTION

In hdf4_handler bes-testsuite eos2 tests, this test:
    hdf4_handlerTest.with_hdfeos2 155

Was failing:
155: BESCMD $abs_srcdir/h4.with_hdfeos2/swath_1_2d_xy_no_dim.hdf.ddx.bescmd FAILED (hdf4_handlerTest.with_hdfeos2.at:277)

On closer  inspection I found that the test baseline contains this DDS:
{code}
Dataset {
    Float32 temperature[NDim = 8][4];
    Float32 Latitude[NDim = 8];
    Float32 Longitude[NDim = 8];
    Int32 [4];
} swath_1_2d_xy_no_dim.hdf;
{code}
This last, nameless, Array is a problem and indicates a bug in the handler and the tests are only passing for this group (swath_1_2d_xy_no_dim.hdf.*) because the baselines match the result, not because the result is correct.

I have commented out the failing test in: {{hdf4_handler/bes-testsuite/hdf4_handlerTest.with_hdfeos2.at}} with a reference to this issue. 

When we get the bug fixed we can reenable this test.
